### PR TITLE
Feature/initiate terraform code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ workflows:
             - hold-apply     
       - build:
           requires: 
-            - plan-apply
+            - apply
       - deploy:
           requires: 
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,37 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
+  plan-apply:
+    working_directory: /go/src/github.com/servian/TechChallengeApp
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - checkout
+      - run:
+          name: terraform init & plan
+          command: |
+            cd infrastructure
+            terraform init -input=false
+            terraform plan -out tfapply  
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  apply:
+    docker:
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:light
+    steps:
+      - attach_workspace:
+         at: .
+      - run:
+          name: terraform
+          command: |
+            cd infrastructure
+            terraform apply -auto-approve tfapply
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
   build:
     working_directory: /go/src/github.com/servian/TechChallengeApp
     docker:
@@ -176,7 +207,17 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build
+      - plan-apply 
+      - hold-apply:
+          type: approval
+          requires:
+            - plan-apply
+      - apply:
+          requires:
+            - hold-apply     
+      - build:
+          requires: 
+            - plan-apply
       - deploy:
           requires: 
             - build

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.so
 *.dylib
 .DS_Store
+*.tfvars
+backend.tf
+.terraform/
+.terraform.*
 
 # Test binary, build with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ WORKDIR /TechChallengeApp
 
 COPY conf.toml ./conf.toml
 COPY --from=build /TechChallengeApp TechChallengeApp
-
-ENTRYPOINT [ "./TechChallengeApp" ]
+EXPOSE 3000
+ENTRYPOINT [ "./TechChallengeApp"]

--- a/infrastructure/aws-resources.tf
+++ b/infrastructure/aws-resources.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+  backend "s3" {
+    bucket         = "techchallange"
+    key            = "servian/s3/challange.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "techchallenge-dynamodb-table"
+  }
+}
+
+output "s3_bucket_name" {
+  value = "techchallange"
+}
+output "tf_state_file" {
+  value = "servian/s3/challange.tfstate"
+}
+# Configure the AWS Provider
+provider "aws" {
+  region = var.region
+}
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = "techchallenge-dynamodb-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,6 @@
+variable "region" {
+  default = "ap-southeast-2"
+  type    = string
+}
+
+ 

--- a/manishsolution.md
+++ b/manishsolution.md
@@ -1,0 +1,12 @@
+10March2022 - Design approach
+===========
+Problem Statement: - Deploy TechChallenge APP to any cloud platform.
+ 0). Setup pipeline possibily using CircleCI with github trigger.
+ 0). Setup network infra for deployment (infra as code)
+ 1). Set up new postgres database(infra as code)
+ 2). Run app with updatedb option to generate tables (pipeline-docker)
+ 3). Provide the database configuration to web app and launch (pipeline-docker)
+ 4). Test connectivity on public dns
+
+
+1) Planning Create Terraform code to deploy database and setup ECS 


### PR DESCRIPTION
### Description
feature: setup pipeline to use Terraform for infrastructure setup
1). create initial terraform code to setup AWS provider
2). update pipeline to run terraform plan and apply
3). Created S3 bucket manually. Setup AWS credentials in CircleCI environment variables
3) manage terraform state in S3 bucket with DynamoDB state lock to avoid issues with concurrent running of pipeline

### Checklist

- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added issue number to `Fixes` line above
![image](https://user-images.githubusercontent.com/46772011/157780845-ca2d1e09-4fd5-4cd1-9246-4940dc6b6e6a.png)
