### PR TITLE
fix: remove var-file paramenter from terraform apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             cat variables.tfvars
             terraform init -input=false
             terraform plan -out tfapply -var-file variables.tfvars
-            terraform apply -auto-approve tfapply -var-file variables.tfvars            
+            terraform apply -auto-approve tfapply           
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
### Description
fix issue number wasn't created
terraform apply had --var-file parameter

### Checklist

- [X] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [] Added issue number to `Fixes` line above
